### PR TITLE
Upgrade justinrainbow/json-schema package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
         "webtoolshealth/php-coding-standard": "^1.0"
     },
     "require": {
-        "justinrainbow/json-schema": "^5.2",
         "php": "^8.3|^8.4",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/support": "^11.0|^12.0",
+        "justinrainbow/json-schema": "^6.5.1"
     },
     "config": {
         "sort-packages": true

--- a/src/Validation/JsonSchemaValidator.php
+++ b/src/Validation/JsonSchemaValidator.php
@@ -41,7 +41,8 @@ class JsonSchemaValidator implements ValidatorContract
 
         foreach ($this->validator->getErrors(SchemaValidator::ERROR_DOCUMENT_VALIDATION) as $error) {
             $this->messages->add($error['property'], $error['message']);
-            $this->failedConstraints->add($error['property'], $error['constraint']);
+            $constraint = is_array($error['constraint']) ? $error['constraint']['name'] : $error['constraint'];
+            $this->failedConstraints->add($error['property'], $constraint);
         }
 
         foreach ($this->after as $after) {

--- a/tests/JsonSchemaValidatorTest.php
+++ b/tests/JsonSchemaValidatorTest.php
@@ -74,7 +74,7 @@ class JsonSchemaValidatorTest extends TestCase
         $validator->validated();
     }
 
-    public function test_somtimes_is_a_no_op()
+    public function test_sometimes_is_a_no_op()
     {
         $validator = new JsonSchemaValidator(new Validator(), $this->schema, $this->validPayload);
 
@@ -104,7 +104,7 @@ class JsonSchemaValidatorTest extends TestCase
         $this->assertSame([
             'last_name' => ['required'],
             'first_name' => ['type'],
-            'email' => ['format'],
+            'email' => ['emailFormat'],
             '' => ['additionalProp'],
         ], $validator->failed());
     }


### PR DESCRIPTION
Upgrade justinrainbow/json-schema package

## Summary

Upgrades the justinrainbow/json-schema package from ^5.2 to ^6.5.1.

## Changes

 - composer.json: Updated dependency version constraint for justinrainbow/json-schema from ^5.2 to ^6.5.1
 - JsonSchemaValidator.php: Added compatibility handling for the new error constraint format (v6 returns constraints
as arrays with a name property)
 - JsonSchemaValidatorTest.php:
   - Fixed typo in test method name (somtimes → sometimes)
   - Updated test expectation for emailFormat constraint (changed from format to match v6 behavior)

## Breaking Changes

⚠️ Constraint names have changed in json-schema v6: The failed() method now returns different constraint names. For
   example:

 - format → emailFormat (for email validation)
 - Other constraint names may have changed as well

   Impact: If you're checking the output of failed() for specific constraint names in your code, you'll need to update
   those checks to use the new constraint names.

## Testing

Existing tests updated to reflect new constraint naming convention in json-schema v6.